### PR TITLE
@ #17 | fix missing selector

### DIFF
--- a/incubator/mysqlha/templates/statefulset.yaml
+++ b/incubator/mysqlha/templates/statefulset.yaml
@@ -9,6 +9,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   serviceName: {{ template "fullname" . }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
   replicas: {{ .Values.mysqlha.replicaCount }}
   {{- if .Values.updateStrategy }}
   updateStrategy:


### PR DESCRIPTION
To fix this error

```bash
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(StatefulSet.spec.replicas): invalid type for io.k8s.api.apps.v1.StatefulSetSpec.replicas: got "string", expected "integer", ValidationError(StatefulSet.spec): missing required field "selector" in io.k8s.api.apps.v1.StatefulSetSpec]
```