### PR TITLE
fix lint-test due to python version not available

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.0
+          python-version: 3.7.12
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.1.0


### PR DESCRIPTION
Version 3.7.0 with arch x64 not found The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json